### PR TITLE
Fix bastion command 

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "bastion_proxy_command" {
-  value = "ssh -i ${local_file.bastion_ssh_key_private[0].filename} ubuntu@${aws_instance.bastion[0].public_ip} -D 1234 -C -N"
+  value = length(aws_instance.bastion) > 0 ? "ssh -i ${local_file.bastion_ssh_key_private[0].filename} ubuntu@${aws_instance.bastion[0].public_ip} -D 1234 -C -N" : "Not applicable - no bastion"
 }
 
 output "kubernetes_api_sample_command" {


### PR DESCRIPTION
* Last merge to master failed to cleanup with the following error:
```
Error: Invalid index
  on ../../outputs.tf line 2, in output "bastion_proxy_command":
   2:   value = "ssh -i ${local_file.bastion_ssh_key_private[0].filename} ubuntu@${aws_instance.bastion[0].public_ip} -D 1234 -C -N"
    |----------------
    | local_file.bastion_ssh_key_private is empty tuple
```
* @kaxil mentioned to change the bastion_proxy_command  to something like https://github.com/astronomer/terraform-google-astronomer-gcp/blob/460ee301908037593b4dc2cf5424733dc9a48744/outputs.tf#L1-L4
```
output "bastion_proxy_command" {
  value = length(google_compute_instance.bastion) > 0 ? "gcloud beta compute ssh --zone ${google_compute_instance.bastion[0].zone} ${google_compute_instance.bastion[0].name} --tunnel-through-iap --ssh-flag='-L 1234:127.0.0.1:8888 -C -N'" : "Not applicable - no bastion"
}
```