### PR TITLE
Remove bastion output causing pipeline failure

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,3 @@
-output "bastion_proxy_command" {
-  value = length(aws_instance.bastion) > 0 ? "ssh -i ${local_file.bastion_ssh_key_private[0].filename} ubuntu@${aws_instance.bastion[0].public_ip} -D 1234 -C -N" : "Not applicable - no bastion"
-}
-
 output "kubernetes_api_sample_command" {
   value = "If you have started the api proxy using the bastion SOCKS5 proxy command, this should work:\nhttps_proxy=socks5://127.0.0.1:1234 kubectl get pods"
 }


### PR DESCRIPTION
* Remove `bastion_proxy_command` output
* Causing the following error
```
Error: Invalid index
  on ../../outputs.tf line 2, in output "bastion_proxy_command":
   2:   value = "ssh -i ${local_file.bastion_ssh_key_private[0].filename} ubuntu@${aws_instance.bastion[0].public_ip} -D 1234 -C -N"
    |----------------
    | local_file.bastion_ssh_key_private is empty tuple
```