### PR TITLE
Aurora replica count and DB subnets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ config-map*
 *.tfvars*
 *.zip
 examples/*/.terraform
+*__pycache__*

--- a/db.tf
+++ b/db.tf
@@ -11,7 +11,7 @@ resource "random_string" "postgres_airflow_password" {
 module "aurora" {
   # does not support Terraform 0.12 in registry, but there was a PR
   # that I copied locally.
-  version = "2.2.0"
+  version = "2.11.0"
   source  = "terraform-aws-modules/rds-aurora/aws"
   # source         = "./modules/terraform-aws-rds-aurora"
   name           = "astrodb-${random_id.db_name_suffix.hex}"

--- a/db.tf
+++ b/db.tf
@@ -18,10 +18,10 @@ module "aurora" {
   engine         = "aurora-postgresql"
   engine_version = "10.6"
 
-  subnets = "${var.vpc_id == "" ? module.vpc.database_subnets : local.private_subnets}"
+  subnets = local.database_subnets
   vpc_id  = local.vpc_id
 
-  replica_count                   = 1
+  replica_count                   = var.db_replica_count
   instance_type                   = var.db_instance_type
   apply_immediately               = true
   skip_final_snapshot             = false
@@ -72,4 +72,3 @@ resource "aws_security_group_rule" "allow_access_from_eks_workers" {
   source_security_group_id = module.eks.worker_security_group_id
   security_group_id        = module.aurora.this_security_group_id
 }
-

--- a/locals.tf
+++ b/locals.tf
@@ -12,11 +12,15 @@ locals {
 
   azs = ["${local.region}a", "${local.region}b"]
 
-  vpc_id = "${var.vpc_id == "" ? module.vpc.vpc_id : var.vpc_id}"
+  vpc_id = var.vpc_id == "" ? module.vpc.vpc_id : var.vpc_id
 
-  private_subnets = "${var.vpc_id == "" ? module.vpc.private_subnets : var.private_subnets}"
+  private_subnets = var.vpc_id == "" ? module.vpc.private_subnets : var.private_subnets
 
-  public_subnets = "${var.vpc_id == "" ? module.vpc.public_subnets : var.public_subnets}"
+  bring_your_own_db_subnets = length(var.db_subnets) > 0 ? var.db_subnets : local.private_subnets
+
+  database_subnets = var.vpc_id == "" ? module.vpc.database_subnets : local.bring_your_own_db_subnets
+
+  public_subnets = var.vpc_id == "" ? module.vpc.public_subnets : var.public_subnets
 
   region = data.aws_region.current.name
 
@@ -27,4 +31,3 @@ locals {
     )
   )
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "private_subnets" {
   description = "This variable does nothing unless vpc_id is also set. Specify the subnet IDs in which the platform will be deployed"
 }
 
+variable "db_subnets" {
+  default     = []
+  type        = "list"
+  description = "This variable does nothing unless vpc_id is also set. Specify the subnet IDs in which the DB will be deployed. If not provided, it will fall back to private_subnets."
+}
+
 variable "public_subnets" {
   default     = []
   type        = "list"
@@ -120,7 +126,7 @@ variable "peer_account_id" {
 }
 
 variable "bastion_astro_cli_version" {
-  default     = "v0.9.3-alpha.2"
+  default     = "v0.10.3"
   type        = string
   description = "The version of astro-cli to install on the bastion host"
 }
@@ -134,4 +140,10 @@ variable "extra_sg_ids_for_eks_security" {
 variable "lets_encrypt" {
   type    = bool
   default = true
+}
+
+variable "db_replica_count" {
+  description = "How many replicas for the database"
+  default     = 1
+  type        = number
 }


### PR DESCRIPTION
- Add ability to set the number of aurora instances. This allows for a multi-AZ configuration
- Add ability to specify DB subnets when using a BYO-subnets configuration
- Bump bastion CLI version
- Related to astronomer/issues#672