### PR TITLE
Bump aurora-postgresql engine version and disable auto_minor_version_upgrade

### DIFF
--- a/db.tf
+++ b/db.tf
@@ -16,7 +16,8 @@ module "aurora" {
   # source         = "./modules/terraform-aws-rds-aurora"
   name           = "astrodb-${random_id.db_name_suffix.hex}"
   engine         = "aurora-postgresql"
-  engine_version = "10.6"
+
+  engine_version             = var.engine_version
 
   subnets = local.database_subnets
   vpc_id  = local.vpc_id

--- a/db.tf
+++ b/db.tf
@@ -14,8 +14,8 @@ module "aurora" {
   version = "2.11.0"
   source  = "terraform-aws-modules/rds-aurora/aws"
   # source         = "./modules/terraform-aws-rds-aurora"
-  name           = "astrodb-${random_id.db_name_suffix.hex}"
-  engine         = "aurora-postgresql"
+  name   = "astrodb-${random_id.db_name_suffix.hex}"
+  engine = "aurora-postgresql"
 
   engine_version             = var.engine_version
   auto_minor_version_upgrade = var.auto_minor_version_upgrade

--- a/db.tf
+++ b/db.tf
@@ -18,6 +18,7 @@ module "aurora" {
   engine         = "aurora-postgresql"
 
   engine_version             = var.engine_version
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
 
   subnets = local.database_subnets
   vpc_id  = local.vpc_id

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,6 @@ variable "db_replica_count" {
 
 variable "local_ip" {
   description = "URL used to find user's local IP for use with bastion host"
-  default     = "http://ipv4.icanhazip.com"
+  default     = "http://checkip.amazonaws.com"
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -164,7 +164,7 @@ variable "engine_version" {
 }
 
 variable "auto_minor_version_upgrade" {
-  description = "Determines whether minor engine upgrades will be performed automatically in the maintenance window"
+  description = "Determines whether minor engine upgrades for Aurora RDS will be performed automatically in the maintenance window"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -158,7 +158,13 @@ variable "local_ip" {
 }
 
 variable "engine_version" {
-  description = "Aurora database engine version"
+  description = "Aurora database engine version."
   type        = string
   default     = "10.7"
+}
+
+variable "auto_minor_version_upgrade" {
+  description = "Determines whether minor engine upgrades will be performed automatically in the maintenance window"
+  type        = bool
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -156,3 +156,9 @@ variable "local_ip" {
   default     = "http://checkip.amazonaws.com"
   type        = string
 }
+
+variable "engine_version" {
+  description = "Aurora database engine version"
+  type        = string
+  default     = "10.7"
+}


### PR DESCRIPTION
* Update `variable.local_ip` URL
    + Replaced `ipv4.icanhazip.com` with `checkip.amazonaws.com`

* Bump **aurora-postgresql** `engine_version` to `10.7`
    + Also created variable to hold `engine_version` for **aurora-postgresql**

* Set **aurora-postgresql** `auto_minor_version_upgrade` to `false`
    + Created variable to allow export and override

Relates to:

* <https://support.astronomer.io/hc/en-us/requests/1281>
* <https://forum.astronomer.io/t/disable-auto-minor-version-upgrade-for-aurora-rds-cluster/447>