### PR TITLE
Increase cluster create timeout to 30m

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -30,8 +30,9 @@ module "eks" {
   version = "8.1.0"
   # source = "./modules/terraform-aws-eks"
 
-  cluster_name    = local.cluster_name
-  cluster_version = var.cluster_version
+  cluster_name           = local.cluster_name
+  cluster_version        = var.cluster_version
+  cluster_create_timeout = "30m"
 
   subnets = local.private_subnets
 


### PR DESCRIPTION
- We periodically see our terraform fail due to timeout creating EKS cluster
- The EKS module we use has since bumped this default value from 15m to 30m
- Bumping this value while we decide whether or not to bump the entire EKS module
- Related to astronomer/issues#1377