### PR TITLE
Provide capability to specify cidr prefix for ingress rule of bastion host

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -98,7 +98,7 @@ resource "aws_security_group_rule" "bastion_connection_to_private_kube_api" {
   description       = "Connect the bastion to the EKS private endpoint"
   security_group_id = module.eks.cluster_security_group_id
 
-  cidr_blocks = ["${aws_instance.bastion[0].private_ip}/32"]
+  cidr_blocks = ["${aws_instance.bastion[0].private_ip}/${bastion_ingress_cidr_prefix}"]
   from_port   = 443
   to_port     = 443
   protocol    = "tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -168,3 +168,9 @@ variable "auto_minor_version_upgrade" {
   type        = bool
   default     = false
 }
+
+variable "bastion_ingress_cidr_prefix" {
+  description = "Prefix of local_ip used as ingress for bastion"
+  default     = 32
+  type        = number
+}


### PR DESCRIPTION
1. In order to provide access of bastion host to wider IPs, make it as a variable instead of hard coded value "32"