### PR TITLE
Update aurora module to 2.14.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: terraform-aws-astronomer-aws
 steps:
 
 - name: lint
-  image: hashicorp/terraform:light
+  image: hashicorp/terraform:0.12.29 
   commands:
     - cp providers.tf.example providers.tf
     - terraform init
@@ -27,7 +27,7 @@ steps:
       - push
 
 - name: from_scratch
-  image: hashicorp/terraform:light
+  image: hashicorp/terraform:0.12.29
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -53,7 +53,7 @@ steps:
       - push
 
 - name: from_scratch_cleanup
-  image: hashicorp/terraform:light
+  image: hashicorp/terraform:0.12.29
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID

--- a/db.tf
+++ b/db.tf
@@ -11,7 +11,7 @@ resource "random_string" "postgres_airflow_password" {
 module "aurora" {
   # does not support Terraform 0.12 in registry, but there was a PR
   # that I copied locally.
-  version = "2.11.0"
+  version = "2.14.0"
   source  = "terraform-aws-modules/rds-aurora/aws"
   # source         = "./modules/terraform-aws-rds-aurora"
   name   = "astrodb-${random_id.db_name_suffix.hex}"

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "admin_email" {
 }
 
 variable "cluster_version" {
-  default = "1.14"
+  default = "1.17"
   type    = string
 }
 


### PR DESCRIPTION
- Aurora module `v2.11.0` has a deprecated attribute that is resolved in `v2.14.0`
- Related change https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/commit/d203fc3fa5f22441654771198ecbe3185916cf13#diff-7a370d8342e7203b805911c92454f0f4
- Bump to `terraform-aws-rds-aurora` `v2.14.0` to patch this bug
- Related to https://github.com/astronomer/issues/issues/1913