### PR TITLE
Terraform v0.13.x support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: terraform-aws-astronomer-aws
 steps:
 
 - name: lint
-  image: hashicorp/terraform:0.12.29 
+  image: hashicorp/terraform:0.13.5
   commands:
     - cp providers.tf.example providers.tf
     - terraform init
@@ -27,7 +27,7 @@ steps:
       - push
 
 - name: from_scratch
-  image: hashicorp/terraform:0.12.29
+  image: hashicorp/terraform:0.13.5
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
@@ -53,7 +53,7 @@ steps:
       - push
 
 - name: from_scratch_cleanup
-  image: hashicorp/terraform:0.12.29
+  image: hashicorp/terraform:0.13.5
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
   rev: v1.11.0
   hooks:

--- a/db.tf
+++ b/db.tf
@@ -11,7 +11,7 @@ resource "random_string" "postgres_airflow_password" {
 module "aurora" {
   # does not support Terraform 0.12 in registry, but there was a PR
   # that I copied locally.
-  version = "2.14.0"
+  version = "2.29.0"
   source  = "terraform-aws-modules/rds-aurora/aws"
   # source         = "./modules/terraform-aws-rds-aurora"
   name   = "astrodb-${random_id.db_name_suffix.hex}"

--- a/eks.tf
+++ b/eks.tf
@@ -58,3 +58,56 @@ module "eks" {
 
   tags = local.tags
 }
+
+resource "aws_iam_role_policy_attachment" "workers_autoscaling" {
+  policy_arn = aws_iam_policy.worker_autoscaling.arn
+  role       = module.eks.worker_iam_role_name
+}
+
+resource "aws_iam_policy" "worker_autoscaling" {
+  name_prefix = "eks-worker-autoscaling-${module.eks.cluster_id}"
+  description = "EKS worker node autoscaling policy for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.worker_autoscaling.json
+}
+
+data "aws_iam_policy_document" "worker_autoscaling" {
+  statement {
+    sid    = "eksWorkerAutoscalingAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "eksWorkerAutoscalingOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${module.eks.cluster_id}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+      values   = ["true"]
+    }
+  }
+}

--- a/eks.tf
+++ b/eks.tf
@@ -27,7 +27,7 @@ module "eks" {
   # copy of the pending PRs
   source = "terraform-aws-modules/eks/aws"
   # version of the eks module to use
-  version = "8.1.0"
+  version = "13.2.1"
   # source = "./modules/terraform-aws-eks"
 
   cluster_name           = local.cluster_name

--- a/examples/from_scratch/main.tf
+++ b/examples/from_scratch/main.tf
@@ -25,3 +25,12 @@ resource "local_file" "kubeconfig" {
   content    = module.astronomer_aws_with_vpc.kubeconfig
   filename   = "${path.root}/kubeconfig-${var.deployment_id}"
 }
+
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/into_existing_subnets/main.tf
+++ b/examples/into_existing_subnets/main.tf
@@ -36,3 +36,12 @@ module "astronomer_aws_in_specific_subnet" {
   vpc_id          = module.vpc.vpc_id
   private_subnets = module.vpc.private_subnets
 }
+
+terraform {
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,33 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    acme = {
+      source = "terraform-providers/acme"
+    }
+    archive = {
+      source = "hashicorp/archive"
+    }
+    aws = {
+      source = "hashicorp/aws"
+    }
+    http = {
+      source = "hashicorp/http"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,8 @@ terraform {
       source = "hashicorp/archive"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
     }
     http = {
       source = "hashicorp/http"


### PR DESCRIPTION
- Bump aurora module for terraform v0.13 support
- Bump eks module for terraform v0.13 support
- Update pipeline for terraform v0.13 support
- Add required providers to this module

Related to https://github.com/astronomer/issues/issues/1910