### PR TITLE
Use ipify vs icanhazip

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ variable "db_replica_count" {
 
 variable "local_ip" {
   description = "URL used to find user's local IP for use with bastion host"
-  default     = "http://ipv4.icanhazip.com"
+  default     = "https://api.ipify.org"
   type        = string
 }
 


### PR DESCRIPTION
icanhazip.com has caused some issues in the past due to being unavailable. This change swiches to ipify.org

Example failure: <https://app.circleci.com/pipelines/github/astronomer/google-environments/8177/workflows/acd7356d-f3a3-4cdb-9628-a26eebe53192/jobs/11737>

Related to astronomer/issues#2290