### PR TITLE
Merge apply and destroy jobs into one job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,16 +35,6 @@ jobs:
           event: fail
           template: basic_fail_1
 
-  # terraform_destroy:
-  #   docker:
-  #     - image: quay.io/astronomer/ci-terraform:2020-12
-  #   steps:
-  #     - checkout
-  #     - run: DESTROY=1 EXAMPLE=from_scratch pipeline/run_terraform.sh
-  #     - slack/notify:
-  #         event: fail
-  #         template: basic_fail_1
-
   git_tag:
     docker:
       - image: quay.io/astronomer/ci-terraform:2020-12
@@ -122,11 +112,6 @@ workflows:
             - terraform_lint
           context:
             - slack
-      # - terraform_destroy:
-      #     requires:
-      #       - terraform_apply
-      #     context:
-      #       - slack
       - git_tag:
           context:
             - github-repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           event: fail
           template: basic_fail_1
 
-  terraform_apply:
+  run_terraform:
     docker:
       - image: quay.io/astronomer/ci-terraform:2020-12
     steps:
@@ -28,16 +28,22 @@ jobs:
       - slack/notify:
           event: fail
           template: basic_fail_1
-
-  terraform_destroy:
-    docker:
-      - image: quay.io/astronomer/ci-terraform:2020-12
-    steps:
-      - checkout
-      - run: DESTROY=1 EXAMPLE=from_scratch pipeline/run_terraform.sh
+      - run:
+          command: DESTROY=1 EXAMPLE=from_scratch pipeline/run_terraform.sh
+          when: always
       - slack/notify:
           event: fail
           template: basic_fail_1
+
+  # terraform_destroy:
+  #   docker:
+  #     - image: quay.io/astronomer/ci-terraform:2020-12
+  #   steps:
+  #     - checkout
+  #     - run: DESTROY=1 EXAMPLE=from_scratch pipeline/run_terraform.sh
+  #     - slack/notify:
+  #         event: fail
+  #         template: basic_fail_1
 
   git_tag:
     docker:
@@ -111,22 +117,22 @@ workflows:
       - terraform_lint:
           context:
             - slack
-      - terraform_apply:
+      - run_terraform:
           requires:
             - terraform_lint
           context:
             - slack
-      - terraform_destroy:
-          requires:
-            - terraform_apply
-          context:
-            - slack
+      # - terraform_destroy:
+      #     requires:
+      #       - terraform_apply
+      #     context:
+      #       - slack
       - git_tag:
           context:
             - github-repo
             - slack
           requires:
-            - terraform_destroy
+            - run_terraform
           filters:
             branches:
               only:

--- a/pipeline/run_terraform.sh
+++ b/pipeline/run_terraform.sh
@@ -10,7 +10,7 @@ cp backend.tf.example examples/"$EXAMPLE"/backend.tf
 cd examples/"$EXAMPLE"
 
 if [ "${DESTROY:-0}" -eq 1 ]; then
-  DEPLOYMENT_ID=ci$(echo "$CIRCLE_PROJECT_REPONAME$CIRCLE_BUILD_NUM" | md5sum | awk '{print substr($1,0,30)}')
+  DEPLOYMENT_ID=ci$(echo "${CIRCLE_PROJECT_REPONAME}${CIRCLE_BUILD_NUM}" | md5sum | awk '{print substr($1,0,30)}')
   echo "$DEPLOYMENT_ID"
   sed -i "s/REPLACE/$DEPLOYMENT_ID/g" backend.tf
   $TERRAFORM init

--- a/pipeline/run_terraform.sh
+++ b/pipeline/run_terraform.sh
@@ -10,7 +10,7 @@ cp backend.tf.example examples/"$EXAMPLE"/backend.tf
 cd examples/"$EXAMPLE"
 
 if [ "${DESTROY:-0}" -eq 1 ]; then
-  DEPLOYMENT_ID=ci$(echo "$CIRCLE_PROJECT_REPONAME$CIRCLE_PREVIOUS_BUILD_NUM" | md5sum | awk '{print substr($1,0,30)}')
+  DEPLOYMENT_ID=ci$(echo "$CIRCLE_PROJECT_REPONAME$CIRCLE_BUILD_NUM" | md5sum | awk '{print substr($1,0,30)}')
   echo "$DEPLOYMENT_ID"
   sed -i "s/REPLACE/$DEPLOYMENT_ID/g" backend.tf
   $TERRAFORM init


### PR DESCRIPTION
- Merge `terraform_apply` and `terraform_destroy` jobs into one job, `run_terraform`
- This avoids inconsistency in build number, which was causing `terraform_destroy` to fail