### PR TITLE
Update tag value in slack notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Tag*:\n1.2.<< pipeline.number >>"
+                      "text": "*Tag*:\n2.0.<< pipeline.number >>"
                     }
                   ],
                   "accessory": {


### PR DESCRIPTION
- Slack notifications for successful tags show the wrong tag `1.2.x`
- Update to proper tag `2.0.x`