### PR TITLE
Change default postgres engine value to 11.9

### DIFF
--- a/db.tf
+++ b/db.tf
@@ -43,14 +43,14 @@ module "aurora" {
 
 resource "aws_db_parameter_group" "aurora_db_postgres_parameter_group" {
   name        = "${var.deployment_id}-aurora-db-postgres-parameter-group-${random_id.db_name_suffix.hex}"
-  family      = "aurora-postgresql10"
+  family      = local.db_parameter_group_family
   description = "${var.deployment_id}-aurora-db-postgres-parameter-group"
   tags        = local.tags
 }
 
 resource "aws_rds_cluster_parameter_group" "aurora_cluster_postgres_parameter_group" {
   name        = "${var.deployment_id}-aurora-postgres-cluster-parameter-group-${random_id.db_name_suffix.hex}"
-  family      = "aurora-postgresql10"
+  family      = local.db_parameter_group_family
   description = "${var.deployment_id}-aurora-postgres-cluster-parameter-group"
   tags        = local.tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -30,4 +30,7 @@ locals {
       "Deployment ID", var.deployment_id
     )
   )
+
+  db_parameter_group_family = join("", ["aurora-postgresql", split(".", var.engine_version)[0]])
+
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "tls_key" {
 }
 
 output "tls_cert" {
-  value     = !var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
+  value     = ! var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
 ${acme_certificate.lets_encrypt[0].certificate_pem}
 ${acme_certificate.lets_encrypt[0].issuer_pem}
 EOF

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "tls_key" {
 }
 
 output "tls_cert" {
-  value     = ! var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
+  value     = !var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
 ${acme_certificate.lets_encrypt[0].certificate_pem}
 ${acme_certificate.lets_encrypt[0].issuer_pem}
 EOF

--- a/variables.tf
+++ b/variables.tf
@@ -160,7 +160,7 @@ variable "local_ip" {
 variable "engine_version" {
   description = "Aurora database engine version."
   type        = string
-  default     = "10.7"
+  default     = "11.9"
 }
 
 variable "auto_minor_version_upgrade" {


### PR DESCRIPTION
As per AWS documentation, 10.7 is no longer supported.
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html#AuroraPostgreSQL.Updates.20180305.23

TF throws an error when installing Astronomer Platform. 10.7 is also not available via the UI.
