### PR TITLE
Bump aws ~> 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Terraform Module for Astronomer for AWS
 
-[![Build Status](https://cloud.drone.io/api/badges/astronomer/terraform-aws-astronomer-aws/status.svg)](https://cloud.drone.io/astronomer/terraform-aws-astronomer-aws)
-
 [Terraform](https://www.terraform.io/) is a simple and powerful tool that lets us write, plan and create infrastructure as code. This code will allow you to efficiently provision the infrastructure required to run the Astronomer platform.
 
 ## Features

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "tls_key" {
 }
 
 output "tls_cert" {
-  value     = !var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
+  value     = ! var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
 ${acme_certificate.lets_encrypt[0].certificate_pem}
 ${acme_certificate.lets_encrypt[0].issuer_pem}
 EOF

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "tls_key" {
 }
 
 output "tls_cert" {
-  value     = ! var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
+  value     = !var.lets_encrypt ? "Not applicable - lets_encrypt is not enabled." : <<EOF
 ${acme_certificate.lets_encrypt[0].certificate_pem}
 ${acme_certificate.lets_encrypt[0].issuer_pem}
 EOF

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.2"
+      version = "4.2.0"
     }
     http = {
       source = "hashicorp/http"

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "4.2.0"
+      version = "~> 4.2"
     }
     http = {
       source = "hashicorp/http"

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.2"
     }
     http = {
       source = "hashicorp/http"

--- a/vpc.tf
+++ b/vpc.tf
@@ -6,7 +6,7 @@
 module "vpc" {
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.47.0"
+  version = "2.58.0"
 
   create_vpc = var.vpc_id == "" ? true : false
 


### PR DESCRIPTION
Related to https://github.com/astronomer/issues/issues/4285

- Bump to aws ~> 4.2
- Remove drone CI badge
- pre-commit auto-reformatting
- Bump aws vpc version to 2.58.0 to remove aws provider constraint

This change came out of [an internal discussion](https://astronomer.slack.com/archives/C0179EM5DBP/p1645629345651339) about missing tags. Apparently the aws ~> 3.62.0 version we are using does not support default_tags so no tags are being added to any resources.